### PR TITLE
Checkpoint sync url tests

### DIFF
--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -85,6 +85,31 @@ fn wss_checkpoint_flag() {
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.chain.weak_subjectivity_checkpoint, state));
 }
+
+#[test]
+fn checkpoint_sync_url() {
+    CommandLineTest::new()
+        .flag(
+            "checkpoint-sync-url",
+            Some("http://localhost:9545,https://infura.io/secret"),
+            // TODO: use more appropriate urls as example
+        )
+        .run_with_zero_port()
+        .with_config(|config| {
+            match &config.genesis {
+                beacon_node::ClientGenesis::CheckpointSyncUrl {
+                    genesis_state_bytes,
+                    url,
+                } => {
+                    println!("URL received: {:?}", url);
+                    todo!("Here we need to verify that the urls are what we expect. Check eth1_endpoints_flag for a good example")},
+                other => {
+                    panic!("genesis should use a checkpoint url")
+                }
+            }
+        });
+}
+
 #[test]
 fn max_skip_slots_flag() {
     CommandLineTest::new()

--- a/lighthouse/tests/main.rs
+++ b/lighthouse/tests/main.rs
@@ -1,4 +1,3 @@
-#![cfg(not(debug_assertions))]
 
 mod account_manager;
 mod beacon_node;


### PR DESCRIPTION
Adds the boilerplate for tests regarding the checkpoint-sync-url flag.
You can run them by going to the `lighthouse/lighthouse` directory and running `cargo test checkpoint_sync_url`
This test is failing currently